### PR TITLE
Implement a `Connection.execute` function

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
 
     steps:
       - name: Checkout repository
@@ -24,13 +24,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: pip install -e ".[test]"
+        run: pip install -e . --group test
       - name: Check types
         run: mypy sqlite_anyio
       - name: Run tests
+        if: ${{ !((matrix.python-version == '3.14') && (matrix.os == 'ubuntu-latest')) }}
         run: pytest --color=yes -v tests
       - name: Run code coverage
-        if: ${{ (matrix.python-version == '3.12') && (matrix.os == 'ubuntu-latest') }}
+        if: ${{ (matrix.python-version == '3.14') && (matrix.os == 'ubuntu-latest') }}
         run: |
           coverage run -m pytest tests
           coverage report --fail-under=100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "hatchling.build"
 name = "sqlite-anyio"
 description = "Asynchronous client for SQLite using AnyIO"
 readme = "README.md"
+version = "0.2.3"
 authors = [
     {name = "Alex Grönholm", email = "alex.gronholm@nextday.fi"},
     {name = "David Brochart", email = "david.brochart@gmail.com"},
@@ -19,24 +20,23 @@ classifiers = [
     "Topic :: Database",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
-requires-python = ">= 3.8"
+requires-python = ">= 3.10"
 dependencies = [
     "anyio >=4.0,<5.0",
 ]
-dynamic = ["version"]
 
-[project.optional-dependencies]
+[dependency-groups]
 test = [
-    "pytest >=8,<9",
-    "trio >=0.24.0,<0.25",
+    "pytest >=9,<10",
+    "trio >=0.32.0,<1",
     "mypy",
-    "coverage[toml] >=7,<8",
+    "coverage",
 ]
 
 [project.urls]

--- a/sqlite_anyio/__init__.py
+++ b/sqlite_anyio/__init__.py
@@ -8,5 +8,5 @@ from .sqlite import exception_logger as exception_logger
 
 try:
     __version__ = importlib.metadata.version("sqlite_anyio")
-except importlib.metadata.PackageNotFoundError:
+except importlib.metadata.PackageNotFoundError:  # pragma: nocover
     __version__ = "unknown"

--- a/sqlite_anyio/__init__.py
+++ b/sqlite_anyio/__init__.py
@@ -1,6 +1,12 @@
+import importlib.metadata
+
 from .sqlite import Connection as Connection
 from .sqlite import Cursor as Cursor
 from .sqlite import connect as connect
 from .sqlite import exception_logger as exception_logger
 
-__version__ = "0.2.3"
+
+try:
+    __version__ = importlib.metadata.version("sqlite_anyio")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"

--- a/sqlite_anyio/sqlite.py
+++ b/sqlite_anyio/sqlite.py
@@ -45,6 +45,12 @@ class Connection:
         if self._exception_handler is not None:
             exception_handled = self._exception_handler(exc_type, exc_val, exc_tb, self._log)
         return exception_handled
+    
+    async def execute(self, sql: str, parameters: Sequence[Any] = (), /) -> Cursor:
+        real_cursor = await to_thread.run_sync(self._real_connection.execute, sql, parameters, limiter=self._limiter)
+        return Cursor(real_cursor, self._limiter)
+    
+    update_wrapper(execute, sqlite3.Connection.execute)
 
     async def close(self):
         return await to_thread.run_sync(self._real_connection.close, limiter=self._limiter)

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -18,6 +18,18 @@ async def test_context_manager_commit(anyio_backend):
     await acur1.execute("SELECT name FROM lang")
     assert await acur1.fetchone() == ("Python",)
 
+async def test_context_manager_execute(anyio_backend):
+    mem_uri = f"file:{anyio_backend}_mem0?mode=memory&cache=shared"
+    acon0 = await sqlite_anyio.connect(mem_uri, uri=True)
+    async with acon0:
+        await acon0.execute("CREATE TABLE lang(id INTEGER PRIMARY KEY, name VARCHAR UNIQUE)")
+        await acon0.execute("INSERT INTO lang(name) VALUES(?)", ("Python",))
+
+    acon1 = await sqlite_anyio.connect(mem_uri, uri=True)
+    acur1 = await acon1.cursor()
+    await acur1.execute("SELECT name FROM lang")
+    assert await acur1.fetchone() == ("Python",)
+
 
 async def test_context_manager_rollback(anyio_backend):
     mem_uri = f"file:{anyio_backend}_mem1?mode=memory&cache=shared"

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -17,6 +17,7 @@ async def test_context_manager_commit(anyio_backend):
     acur1 = await acon1.cursor()
     await acur1.execute("SELECT name FROM lang")
     assert await acur1.fetchone() == ("Python",)
+    await acur1.execute("DROP TABLE IF EXISTS lang;")
 
 async def test_context_manager_execute(anyio_backend):
     mem_uri = f"file:{anyio_backend}_mem0?mode=memory&cache=shared"
@@ -29,6 +30,7 @@ async def test_context_manager_execute(anyio_backend):
     acur1 = await acon1.cursor()
     await acur1.execute("SELECT name FROM lang")
     assert await acur1.fetchone() == ("Python",)
+    await acur1.execute("DROP TABLE IF EXISTS lang;")
 
 
 async def test_context_manager_rollback(anyio_backend):
@@ -45,6 +47,7 @@ async def test_context_manager_rollback(anyio_backend):
     acur1 = await acon1.cursor()
     await acur1.execute("SELECT name FROM lang")
     assert await acur1.fetchone() is None
+    await acur1.execute("DROP TABLE IF EXISTS lang;")
 
 
 async def test_exception_logger(anyio_backend, caplog):
@@ -59,3 +62,4 @@ async def test_exception_logger(anyio_backend, caplog):
         raise RuntimeError("foo")
 
     assert "SQLite exception" in caplog.text
+    await acur0.execute("DROP TABLE IF EXISTS lang;")


### PR DESCRIPTION
While I was currently in the process of reviving the [stem library](https://github.com/torproject/stem) (that allows for python to communicate with tor) and forking it under a new name, I found this library to be rather useful in helping me fork and migrate many portions of that library on over to __anyio__ which I had planned on changing to allow for full support with libraries such as __fastapi__ and many other server related libraries. Specifically the [manual module](https://github.com/torproject/stem/blob/master/stem/manual.py) that stem carries which is where this library turned out to be very useful. There is currently just one small hurdle that is in standing in my way, there is no way for me to call `sqlite3.Connection.execute` in this library without creating a cursor so I wanted to try and add this in so that my time with the migration process of my upcoming library can be made bit easier, I'm already planning on using cursors however if this pull request is rejected but I wanted to try my luck at getting this feature implemented anyways before continuing with the other thing I mentioned any further. I made sure I checked if for any conversations related to executing from a `sqlite_anyio.Connection` beforehand before sitting down and adding this in. Feel free to let me know if anybody reading this has any other questions about this additional feature I'm attempting to add on in here.