### PR TITLE
implement cancellable queries with interrupt

### DIFF
--- a/src/sqlite_anyio/sqlite.py
+++ b/src/sqlite_anyio/sqlite.py
@@ -3,13 +3,87 @@ from __future__ import annotations
 __all__ = ["connect", "Connection", "Cursor"]
 
 import sqlite3
+import sys
+import threading
 from collections.abc import Callable, Sequence
 from functools import partial, update_wrapper
 from logging import Logger, getLogger
 from types import TracebackType
-from typing import Any
+from typing import Any, TypeVar
 
-from anyio import CapacityLimiter, to_thread
+if sys.version_info >= (3, 11):
+
+    from typing import TypeVarTuple, Unpack
+else:
+    from typing_extensions import TypeVarTuple, Unpack
+
+T_Retval = TypeVar("T_Retval")
+PosArgsT = TypeVarTuple("PosArgsT")
+import anyio
+from anyio import to_thread, from_thread
+
+
+async def _interruptible_dispatch(
+    func: Callable[[Unpack[PosArgsT]], T_Retval],
+    *args: Unpack[PosArgsT],
+    limiter: anyio.CapacityLimiter | None = None,
+) -> T_Retval:
+    # func is always a bound method of a connection or cursor
+    # dynamically grab the connection via __self__
+    try:
+        real_connection = func.__self__.connection
+    except AttributeError:
+        real_connection = func.__self__
+
+    ev = anyio.Event()
+    lock = threading.Lock()
+    need_interrupt = False
+
+    async def cancel_detector() -> None:
+        nonlocal need_interrupt
+        try:
+            await ev.wait()
+        except anyio.get_cancelled_exc_class():
+            # Block progress in the thread while checking this flag.
+            # Our guard_interrupt thread only ever holds the lock briefly,
+            # so there's no risk of blocking the event loop.
+            with lock:
+                # Due to race conditions, the first calls to interrupt may be
+                # ignored. This race is quick so this loop should not cycle much.
+                while need_interrupt:
+                    real_connection.interrupt()
+                    await anyio.lowlevel.cancel_shielded_checkpoint()
+            # we do NOT re-raise the cancellation so that the task group
+            # does not swallow our retval. If a Cancelled is to propagate,
+            # it should come out of to_thread.run_sync
+
+    def guard_interrupt() -> T_Retval:
+        nonlocal need_interrupt
+
+        with lock:
+            from_thread.check_cancelled()
+            need_interrupt = True
+        try:
+            return func(*args)
+        except sqlite3.OperationalError as e:
+            if str(e) == "interrupted":
+                from_thread.check_cancelled()
+            raise
+        finally:
+            need_interrupt = False
+
+    try:
+        async with anyio.create_task_group() as g:
+            g.start_soon(cancel_detector)
+            retval = await to_thread.run_sync(guard_interrupt, limiter=limiter)
+
+            ev.set()
+    except* Exception as e:
+        if len(e.exceptions) == 1:
+            raise e.exceptions[0]
+        raise
+
+    return retval
 
 
 class Connection:
@@ -22,7 +96,7 @@ class Connection:
         self._real_connection = _real_connection
         self._exception_handler = _exception_handler
         self._log = _log or getLogger(__name__)
-        self._limiter = CapacityLimiter(1)
+        self._limiter = anyio.CapacityLimiter(1)
 
     async def __aenter__(self) -> Connection:
         return self
@@ -47,22 +121,26 @@ class Connection:
         return exception_handled
 
     async def execute(self, sql: str, parameters: Sequence[Any] = (), /) -> Cursor:
-        real_cursor = await to_thread.run_sync(self._real_connection.execute, sql, parameters, limiter=self._limiter)
+        real_cursor = await _interruptible_dispatch(self._real_connection.execute, sql,
+                                                    parameters, limiter=self._limiter)
         return Cursor(real_cursor, self._limiter)
 
     update_wrapper(execute, sqlite3.Connection.execute)
 
     async def close(self):
+      with anyio.CancelScope(shield=True):
         return await to_thread.run_sync(self._real_connection.close, limiter=self._limiter)
 
     update_wrapper(close, sqlite3.Connection.close)
 
     async def commit(self):
-        return await to_thread.run_sync(self._real_connection.commit, limiter=self._limiter)
+        return await _interruptible_dispatch(self._real_connection.commit,
+                                             limiter=self._limiter)
 
     update_wrapper(commit, sqlite3.Connection.commit)
 
     async def rollback(self):
+      with anyio.CancelScope(shield=True):
         return await to_thread.run_sync(self._real_connection.rollback, limiter=self._limiter)
 
     update_wrapper(rollback, sqlite3.Connection.rollback)
@@ -73,7 +151,8 @@ class Connection:
 
 
 class Cursor:
-    def __init__(self, real_cursor: sqlite3.Cursor, limiter: CapacityLimiter) -> None:
+    def __init__(self, real_cursor: sqlite3.Cursor, limiter: anyio.CapacityLimiter) -> \
+            None:
         self._real_cursor = real_cursor
         self._limiter = limiter
 
@@ -90,40 +169,47 @@ class Cursor:
         return self._real_cursor.arraysize
 
     async def close(self) -> None:
+      with anyio.CancelScope(shield=True):
         await to_thread.run_sync(self._real_cursor.close, limiter=self._limiter)
 
     update_wrapper(close, sqlite3.Cursor.close)
 
     async def execute(self, sql: str, parameters: Sequence[Any] = (), /) -> Cursor:
-        real_cursor = await to_thread.run_sync(self._real_cursor.execute, sql, parameters, limiter=self._limiter)
+        real_cursor = await _interruptible_dispatch(self._real_cursor.execute, sql,
+                                                    parameters, limiter=self._limiter)
         return Cursor(real_cursor, self._limiter)
 
     update_wrapper(execute, sqlite3.Cursor.execute)
 
     async def executemany(self, sql: str, parameters: Sequence[Any], /) -> Cursor:
-        real_cursor = await to_thread.run_sync(self._real_cursor.executemany, sql, parameters, limiter=self._limiter)
+        real_cursor = await _interruptible_dispatch(self._real_cursor.executemany, sql,
+                                                    parameters, limiter=self._limiter)
         return Cursor(real_cursor, self._limiter)
 
     update_wrapper(executemany, sqlite3.Cursor.executemany)
 
     async def executescript(self, sql_script: str, /) -> Cursor:
-        real_cursor = await to_thread.run_sync(self._real_cursor.executescript, sql_script, limiter=self._limiter)
+        real_cursor = await _interruptible_dispatch(self._real_cursor.executescript,
+                                                    sql_script, limiter=self._limiter)
         return Cursor(real_cursor, self._limiter)
 
     update_wrapper(executescript, sqlite3.Cursor.executescript)
 
     async def fetchone(self) -> tuple[Any, ...] | None:
-        return await to_thread.run_sync(self._real_cursor.fetchone, limiter=self._limiter)
+        return await _interruptible_dispatch(self._real_cursor.fetchone,
+                                             limiter=self._limiter)
 
     update_wrapper(fetchone, sqlite3.Cursor.fetchone)
 
     async def fetchmany(self, size: int) -> list[tuple[Any, ...]]:
-        return await to_thread.run_sync(self._real_cursor.fetchmany, size, limiter=self._limiter)
+        return await _interruptible_dispatch(self._real_cursor.fetchmany, size,
+                                             limiter=self._limiter)
 
     update_wrapper(fetchmany, sqlite3.Cursor.fetchmany)
 
     async def fetchall(self) -> list[tuple[Any, ...]]:
-        return await to_thread.run_sync(self._real_cursor.fetchall, limiter=self._limiter)
+        return await _interruptible_dispatch(self._real_cursor.fetchall,
+                                             limiter=self._limiter)
 
     update_wrapper(fetchall, sqlite3.Cursor.fetchall)
 

--- a/src/sqlite_anyio/sqlite.py
+++ b/src/sqlite_anyio/sqlite.py
@@ -81,7 +81,7 @@ async def _interruptible_dispatch(
         if len(eg.exceptions) == 1:
             if isinstance(eg.exceptions[0], Exception):
                 raise eg.exceptions[0]
-        raise
+        raise  # pragma: nocover (would be an internal error that should fail other tests)
 
     return retval
 

--- a/src/sqlite_anyio/sqlite.py
+++ b/src/sqlite_anyio/sqlite.py
@@ -15,9 +15,9 @@ import anyio
 from anyio import to_thread, from_thread
 
 if sys.version_info >= (3, 11):
-
     from typing import TypeVarTuple, Unpack
 else:
+    from exceptiongroup import BaseExceptionGroup
     from typing_extensions import TypeVarTuple, Unpack
 
 T_Retval = TypeVar("T_Retval")
@@ -41,7 +41,6 @@ async def _interruptible_dispatch(
     need_interrupt = False
 
     async def cancel_detector() -> None:
-        nonlocal need_interrupt
         try:
             await ev.wait()
         except anyio.get_cancelled_exc_class():
@@ -78,9 +77,10 @@ async def _interruptible_dispatch(
             g.start_soon(cancel_detector)
             retval = await to_thread.run_sync(guard_interrupt, limiter=self._limiter)
             ev.set()
-    except* Exception as e:
-        if len(e.exceptions) == 1:
-            raise e.exceptions[0]
+    except BaseExceptionGroup as eg:
+        if len(eg.exceptions) == 1:
+            if isinstance(eg.exceptions[0], Exception):
+                raise eg.exceptions[0]
         raise
 
     return retval

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -1,4 +1,3 @@
-import anyio
 import pytest
 import sqlite3
 
@@ -15,7 +14,7 @@ async def acon():
     return await sqlite_anyio.connect(":memory:")
 
 
-async def test_connection_and_close(tmp_path_factory):
+async def test_connection_and_close(tmp_path_factory, monkeypatch):
     dir_path = tmp_path_factory.mktemp("sqlite_cancel")
     adb_path = dir_path / "asqlite_cancel.db"
 
@@ -28,9 +27,18 @@ async def test_connection_and_close(tmp_path_factory):
     assert not adb_path.exists()
     assert acon is None
 
-    with move_on_after(0.0001) as c:
-        acon = await sqlite_anyio.connect(adb_path)
-    # assert c.cancel_called
+    from sqlite3 import connect
+    from time import sleep
+
+    def slow_connect(*args, **kwargs):
+        sleep(0.01)
+        return connect(*args, **kwargs)
+
+    with monkeypatch.context() as m:
+        m.setattr(sqlite3, "connect", slow_connect)
+        with move_on_after(0.001) as c:
+            acon = await sqlite_anyio.connect(adb_path)
+    assert c.cancel_called
     assert acon is not None
 
     with CancelScope() as c:
@@ -118,8 +126,9 @@ async def test_execute_long(acon):
     value = (1000000,)  # Tune this delay for CI
 
     await acur.execute("BEGIN DEFERRED")
-    with move_on_after(0.001):
+    with move_on_after(0.001) as c:
         await acur.execute(command, value)
+    assert c.cancelled_caught
 
     command = """SELECT count(*) FROM foo;"""
     await acur.execute(command)
@@ -137,3 +146,20 @@ async def test_cursor_close(acon):
     with pytest.raises(sqlite3.ProgrammingError) as excinfo:
         res = await acur.execute(command)
     assert str(excinfo.value) == "Cannot operate on a closed cursor."
+
+
+async def test_rollback(acon):
+    acur = await acon.execute("CREATE TABLE foo(bar)")
+    await acon.commit()
+    command = """INSERT INTO foo VALUES
+        (? )
+    """
+    value = (1970,)
+    await acur.execute(command, value)
+
+    with CancelScope() as c:
+        c.cancel()
+        await acon.rollback()
+
+    with pytest.raises(sqlite3.InterfaceError, match="rollback"):
+        await acur.fetchone()  # any cursor method would do

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -1,0 +1,139 @@
+import anyio
+import pytest
+import sqlite3
+
+from anyio import CancelScope, move_on_after
+
+import sqlite_anyio
+
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture(scope="function")
+async def acon():
+    return await sqlite_anyio.connect(":memory:")
+
+
+async def test_connection_and_close(tmp_path_factory):
+    dir_path = tmp_path_factory.mktemp("sqlite_cancel")
+    adb_path = dir_path / "asqlite_cancel.db"
+
+    acon = None
+
+    with CancelScope() as c:
+        c.cancel()
+        acon = await sqlite_anyio.connect(adb_path)
+
+    assert not adb_path.exists()
+    assert acon is None
+
+    with move_on_after(0.0001) as c:
+        acon = await sqlite_anyio.connect(adb_path)
+    # assert c.cancel_called
+    assert acon is not None
+
+    with CancelScope() as c:
+        c.cancel()
+        await acon.close()
+    assert c.cancel_called
+
+    with pytest.raises(sqlite3.ProgrammingError) as excinfo:
+        await acon.cursor()
+    assert str(excinfo.value) == "Cannot operate on a closed database."
+
+    # check that there is no lock on the file, especially for Windows where there can be:
+    # PermissionError: [WinError 32] The process cannot access the file because it is being used by another process
+    adb_path.rename(adb_path.with_suffix(".keep"))
+
+
+async def test_execute(acon):
+    command = "CREATE TABLE connums(num)"
+    ares = None
+    with CancelScope() as c:
+        c.cancel()
+        ares = await acon.execute(command)
+    assert ares is None
+    # with move_on_after(.0001) as c:
+    #     ares = await acon.execute(command)
+    # assert ares is None
+
+    command = """SELECT count(*) FROM sqlite_master
+    WHERE type='table' AND name='connums';"""
+    ares = await acon.execute(command)
+    assert await ares.fetchone() == (0,)
+
+    # cursor too
+    acur = ares
+
+    ares = None
+    command = "CREATE TABLE curnums(num)"
+    with CancelScope() as c:
+        c.cancel()
+        ares = await acur.execute(command)
+    assert await acur.fetchone() is None
+
+    command = """SELECT count(*) FROM sqlite_master
+    WHERE type='table' AND name='curnums';"""
+    ares = await acur.execute(command)
+    assert await ares.fetchone() == (0,)
+
+
+async def test_commit(acon):
+    acur = await acon.execute("BEGIN")
+    await acur.execute("CREATE TABLE foo(bar)")
+    await acur.execute("COMMIT")
+
+    command = """    
+        WITH RECURSIVE c(x) AS
+        (VALUES(1) UNION ALL SELECT x+1 FROM c WHERE x < ?)
+        INSERT INTO foo
+        SELECT x FROM c;
+    """
+    value = (10000,)  # Tune this delay for CI
+
+    await acur.execute("BEGIN DEFERRED")
+    await acur.execute(command, value)
+    with CancelScope() as c:
+        c.cancel()
+        await acon.commit()
+    await acon.rollback()
+
+    command = """SELECT count(*) FROM foo;"""
+    await acur.execute(command)
+    assert await acur.fetchone() < value
+
+
+async def test_execute_long(acon):
+    acur = await acon.execute("BEGIN")
+    await acur.execute("CREATE TABLE foo(bar)")
+    await acur.execute("COMMIT")
+
+    command = """    
+        WITH RECURSIVE c(x) AS
+        (VALUES(1) UNION ALL SELECT x+1 FROM c WHERE x < ?)
+        INSERT INTO foo
+        SELECT x FROM c;
+    """
+    value = (1000000,)  # Tune this delay for CI
+
+    await acur.execute("BEGIN DEFERRED")
+    with move_on_after(0.001):
+        await acur.execute(command, value)
+
+    command = """SELECT count(*) FROM foo;"""
+    await acur.execute(command)
+    assert await acur.fetchone() < value
+
+
+async def test_cursor_close(acon):
+    acur = await acon.cursor()
+    with CancelScope() as c:
+        c.cancel()
+        await acur.close()
+    assert c.cancel_called
+
+    command = "SELECT title FROM movie"
+    with pytest.raises(sqlite3.ProgrammingError) as excinfo:
+        res = await acur.execute(command)
+    assert str(excinfo.value) == "Cannot operate on a closed cursor."


### PR DESCRIPTION
I nerd-sniped myself into implementing cancellation based on the [interrupt](https://docs.python.org/3/library/sqlite3.html#sqlite3.Connection.interrupt) method.  The complexity of the extra dispatch function mainly comes from having to detect cancellation via the appearance of a cancelled exception and then make sure not to accidentally interrupt a different query, but to do better would likely require changes in anyio/trio.

It seems to me that only certain methods should be interruptible and other "cleanup" methods like `close` and `rollback` should be shielded _including_ acquisition of the limiter.

I also have an [alternative implementation](https://github.com/davidbrochart/sqlite-anyio/compare/main...richardsheridan:sqlite-anyio:cancel_progress) based on `set_progress_handler` on a different [branch](https://github.com/richardsheridan/sqlite-anyio/commit/7694f2d95a4a3c03f19de76779d4fce76a42ac71). That one is somewhat cleaner but has the disadvantage of having to deal with a tunable parameter to avoid significant overhead from polling for cancellation.

If there's interest I can update the test suite and clean up the formatting, though I need some input from an actual user on how to best go about forming the test suite. 